### PR TITLE
fix: :bug: Fix psm1 content not being migrated to built module file

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 $BuildPSModule = @{
     Name        = 'PSModuleUtils'
-    Version     = '1.7.0-preview2'
+    Version     = '1.7.0'
     Description = 'A module with helper functions to build and publish PowerShell modules to the PSGallery.'
     Tags        = ('PSEdition_Desktop', 'PSEdition_Core', 'Windows')
 }


### PR DESCRIPTION
Also:
- Fix publish failure when published module can't be found right away
- Add parameter to specify a different license url