### PR TITLE
Update PSScriptAnalyzer settings and add test coverage

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,7 @@
 $BuildPSModule = @{
     Name        = 'PSModuleUtils'
-    Version     = '1.7.9'
+    Version     = '1.8.0-preview1'
+    Guid        = '3c63c38f-c32c-4837-a6fa-0b456f4099ce'
     Description = 'A module with helper functions to build and publish PowerShell modules to the PSGallery.'
     Tags        = ('PSEdition_Desktop', 'PSEdition_Core', 'Windows')
 }

--- a/src/PSModuleUtils.Module.Tests.ps1
+++ b/src/PSModuleUtils.Module.Tests.ps1
@@ -1,4 +1,8 @@
-﻿Describe 'Module Validation' {
+﻿# Pester declares parameters in lowercase (e.g. -name on It).
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '')]
+param ()
+
+Describe 'Module Validation' {
     BeforeAll {
         $Script:module = Get-Item $PSCommandPath.Replace('.Module.Tests.ps1', '.psm1' )
     }

--- a/src/PSModuleUtils.psm1
+++ b/src/PSModuleUtils.psm1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; MaximumVersion = '6.0.0' }, @{ ModuleName = 'PSScriptAnalyzer'; MaximumVersion = '2.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0'; MaximumVersion = '5.*' }, @{ ModuleName = 'PSScriptAnalyzer'; MaximumVersion = '1.*' }
 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '')]
 [CmdletBinding()]
 param ()

--- a/src/private/PSScriptAnalyzerSettings.psd1
+++ b/src/private/PSScriptAnalyzerSettings.psd1
@@ -44,60 +44,86 @@
     # You can use rule configuration to configure rules that support it:
 
     Rules        = @{
-        PSAlignAssignmentStatement       = @{
+        PSAlignAssignmentStatement                 = @{
             Enable         = $true
             CheckHashtable = $true
         }
-        PSAvoidLongLines                 = @{
+        PSAvoidLongLines                           = @{
             Enable            = $true
             MaximumLineLength = 120
         }
-        PSAvoidOverwritingBuiltInCmdlets = @{
+        PSAvoidExclaimOperator                     = @{
+            Enable = $true
+        }
+        PSAvoidMultipleTypeAttributes              = @{
+            Enable = $true
+        }
+        PSAvoidOverwritingBuiltInCmdlets           = @{
+            # core-6.1.0-windows is the newest profile bundled with PSScriptAnalyzer.
             PowerShellVersion = @('core-6.1.0-windows')
         }
-        PSAvoidUsingCmdletAliases        = @{
+        PSAvoidSemicolonsAsLineTerminators         = @{
+            Enable = $true
+        }
+        PSAvoidUsingAllowUnencryptedAuthentication = @{
+            Enable = $true
+        }
+        PSAvoidUsingBrokenHashAlgorithms           = @{
+            Enable = $true
+        }
+        PSAvoidUsingCmdletAliases                  = @{
             allowlist = @()
         }
-        PSPlaceCloseBrace                = @{
+        PSAvoidUsingDoubleQuotesForConstantString  = @{
+            Enable = $true
+        }
+        PSPlaceCloseBrace                          = @{
             Enable             = $true
             NoEmptyLineBefore  = $true
             IgnoreOneLineBlock = $true
             NewLineAfter       = $true
         }
-        PSPlaceOpenBrace                 = @{
+        PSPlaceOpenBrace                           = @{
             Enable             = $true
             OnSameLine         = $true
             NewLineAfter       = $true
             IgnoreOneLineBlock = $true
         }
-        PSProvideCommentHelp             = @{
+        PSProvideCommentHelp                       = @{
             Enable                  = $true
             ExportedOnly            = $false
             BlockComment            = $true
             VSCodeSnippetCorrection = $true
             Placement               = 'before'
         }
-        PSReviewUnusedParameter          = @{
+        PSReviewUnusedParameter                    = @{
             CommandsToTraverse = @()
         }
-        PSUseCompatibleCmdlets           = @{
+        PSUseCompatibleCmdlets                     = @{
+            # core-6.1.0-windows is the newest profile bundled with PSScriptAnalyzer.
             compatibility = @('core-6.1.0-windows')
         }
-        PSUseCompatibleSyntax            = @{
+        PSUseCompatibleSyntax                      = @{
             Enable         = $true
             TargetVersions = @(
-                '6.0',
+                '7.0',
                 '5.1'
             )
         }
-        PSUseConsistentIndentation       = @{
+        PSUseConsistentParameterSetName            = @{
+            Enable = $true
+        }
+        PSUseConsistentParametersKind              = @{
+            Enable = $true
+        }
+        PSUseConsistentIndentation                 = @{
             # Formatting for indentation within bracketed multi-line blocks is wrong. Disable until fixed.
             Enable              = $false
             IndentationSize     = 4
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             Kind                = 'space'
         }
-        PSUseConsistentWhitespace        = @{
+        PSUseConsistentWhitespace                  = @{
             Enable                                  = $true
             CheckInnerBrace                         = $true
             CheckOpenBrace                          = $true
@@ -109,10 +135,13 @@
             CheckParameter                          = $true
             IgnoreAssignmentOperatorInsideHashTable = $true
         }
-        PSUseCorrectCasing               = @{
+        PSUseCorrectCasing                         = @{
             Enable = $true
         }
-        PSUseSingularNouns               = @{
+        PSUseSingleValueFromPipelineParameter      = @{
+            Enable = $true
+        }
+        PSUseSingularNouns                         = @{
             Enable        = $true
             NounAllowList = 'Data', 'Windows'
         }

--- a/src/public/Build-PSModule.Tests.ps1
+++ b/src/public/Build-PSModule.Tests.ps1
@@ -1,3 +1,7 @@
+﻿# Pester declares parameters in lowercase (e.g. -name on It).
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '')]
+param ()
+
 Describe 'Integration Tests' -Tag 'Integration' {
     BeforeAll {
         Import-Module -Name "$PSScriptRoot/../PSModuleUtils.psm1" -Force

--- a/src/public/Build-PSModule.ps1
+++ b/src/public/Build-PSModule.ps1
@@ -128,9 +128,19 @@ function Build-PSModule {
     $projectUri = $repoUrl.Replace($companyName + '@', '').Replace('.git', '')
 
     if (-not $Guid) {
-        $publishedModuleGuid = Find-Module -Name $Name -Repository PSGallery -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty AdditionalMetadata |
-            Select-Object -ExpandProperty GUID
+        $publishedModuleGuid = $null
+        $guidLookupPath = Join-Path -Path $env:TEMP -ChildPath "psmodule-guid-$(( New-Guid ).Guid)"
+        try {
+            New-Item -ItemType Directory -Path $guidLookupPath -Force | Out-Null
+            Save-PSResource -Name $Name -Repository PSGallery -Path $guidLookupPath -TrustRepository -ErrorAction SilentlyContinue
+            $publishedManifest = Get-ChildItem -Path $guidLookupPath -Filter "$Name.psd1" -Recurse | Select-Object -First 1
+            if ($publishedManifest) {
+                $publishedModuleGuid = (Import-PowerShellDataFile -Path $publishedManifest.FullName).Guid
+            }
+        }
+        finally {
+            Remove-Item -Path $guidLookupPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
         $Guid = if ($publishedModuleGuid) {
             $publishedModuleGuid
         }

--- a/src/public/Invoke-PSModuleAnalyzer.Tests.ps1
+++ b/src/public/Invoke-PSModuleAnalyzer.Tests.ps1
@@ -1,0 +1,20 @@
+# Pester declares parameters in lowercase (e.g. -name on It).
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '')]
+param ()
+
+Describe 'Unit Tests' -Tag 'Unit' {
+    BeforeAll {
+        . $PSScriptRoot/Invoke-PSModuleAnalyzer.ps1
+        $cleanFile = Join-Path -Path $TestDrive -ChildPath 'Clean.ps1'
+        "function Get-Clean { 'ok' }" | Set-Content -Path $cleanFile -Encoding utf8
+    }
+
+    It 'should not throw on a clean source directory in fix mode' {
+        { Invoke-PSModuleAnalyzer -SourceDirectory $TestDrive -Fix } | Should -Not -Throw
+    }
+
+    It 'should accept a custom settings file path' {
+        $settings = Resolve-Path -Path "$PSScriptRoot/../private/PSScriptAnalyzerSettings.psd1"
+        { Invoke-PSModuleAnalyzer -SourceDirectory $TestDrive -Settings $settings -Fix } | Should -Not -Throw
+    }
+}

--- a/src/public/Publish-PSModule.Tests.ps1
+++ b/src/public/Publish-PSModule.Tests.ps1
@@ -1,0 +1,64 @@
+# Pester declares parameters in lowercase (e.g. -name on It).
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '')]
+param ()
+
+Describe 'Unit Tests' -Tag 'Unit' {
+    BeforeAll {
+        . $PSScriptRoot/Publish-PSModule.ps1
+    }
+
+    Context 'when no versioned folder exists' {
+        It 'should warn and not publish' {
+            $emptyOutput = Join-Path -Path $TestDrive -ChildPath 'empty'
+            New-Item -ItemType Directory -Path "$emptyOutput/TestModule" -Force | Out-Null
+            Mock Publish-PSResource {}
+            Publish-PSModule `
+                -Name 'TestModule' `
+                -OutputDirectory $emptyOutput `
+                -ApiKey 'fake' `
+                -WarningVariable warnings `
+                -WarningAction SilentlyContinue
+            ( $warnings -join ' ' ) | Should -Match 'No module named TestModule found to publish'
+            Should -Invoke Publish-PSResource -Times 0
+        }
+    }
+
+    Context 'when a versioned folder exists' {
+        BeforeEach {
+            $script:moduleOutput = Join-Path -Path $TestDrive -ChildPath 'out'
+            $script:versionedFolder = Join-Path -Path $script:moduleOutput -ChildPath 'TestModule/1.0.0'
+            New-Item -ItemType Directory -Path $script:versionedFolder -Force | Out-Null
+            New-ModuleManifest `
+                -Path (Join-Path -Path $script:versionedFolder -ChildPath 'TestModule.psd1') `
+                -ModuleVersion '1.0.0' `
+                -Author 'Tester' `
+                -Description 'Stub module for tests.'
+            Set-Content -Path (Join-Path -Path $script:versionedFolder -ChildPath 'TestModule.psm1') -Value '# empty'
+
+            Mock Publish-PSResource {}
+            Mock Find-PSResource {
+                [PSCustomObject]@{ Name = 'TestModule'; Version = '1.0.0' }
+            }
+        }
+
+        It 'should call Publish-PSResource with the versioned folder path' {
+            Publish-PSModule -Name 'TestModule' -OutputDirectory $script:moduleOutput -ApiKey 'fake'
+            Should -Invoke Publish-PSResource -Times 1 -Exactly -ParameterFilter {
+                $Path -eq $script:versionedFolder -and $Repository -eq 'PSGallery'
+            }
+        }
+
+        It 'should throw after exhausting Find-PSResource retries' {
+            Mock Find-PSResource { throw 'not found yet' }
+            Mock Start-Sleep {}
+            {
+                Publish-PSModule `
+                    -Name 'TestModule' `
+                    -OutputDirectory $script:moduleOutput `
+                    -ApiKey 'fake' `
+                    -WarningAction SilentlyContinue
+            } | Should -Throw
+            Should -Invoke Find-PSResource -Times 5 -Exactly
+        }
+    }
+}

--- a/src/public/Test-PSModule.Tests.ps1
+++ b/src/public/Test-PSModule.Tests.ps1
@@ -1,0 +1,48 @@
+# Pester declares parameters in lowercase (e.g. -name on It).
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '')]
+param ()
+
+Describe 'Unit Tests' -Tag 'Unit' {
+    BeforeAll {
+        . $PSScriptRoot/Test-PSModule.ps1
+    }
+
+    Context 'when no test files are found' {
+        It 'should warn and not invoke Pester' {
+            $emptyDir = Join-Path -Path $TestDrive -ChildPath 'no-tests'
+            New-Item -ItemType Directory -Path $emptyDir -Force | Out-Null
+            Mock Invoke-Pester {}
+            Test-PSModule `
+                -Name 'TestModule' `
+                -SourceDirectory $emptyDir `
+                -WarningVariable warnings `
+                -WarningAction SilentlyContinue
+            ( $warnings -join ' ' ) | Should -Match 'No test files found'
+            Should -Invoke Invoke-Pester -Times 0
+        }
+    }
+
+    Context 'when test files are present' {
+        BeforeEach {
+            $script:testDir = Join-Path -Path $TestDrive -ChildPath 'with-tests'
+            New-Item -ItemType Directory -Path $script:testDir -Force | Out-Null
+            $sample = 'Describe "x" { It "y" { $true | Should -BeTrue } }'
+            Set-Content -Path (Join-Path -Path $script:testDir -ChildPath 'Sample.Tests.ps1') -Value $sample
+            Mock Invoke-Pester {}
+        }
+
+        It 'should invoke Pester with the source directory in the configuration' {
+            Test-PSModule -Name 'TestModule' -SourceDirectory $script:testDir
+            Should -Invoke Invoke-Pester -Times 1 -Exactly -ParameterFilter {
+                $Configuration.Run.Path.Value -contains $script:testDir
+            }
+        }
+
+        It 'should set a Tag filter when -Tag is provided' {
+            Test-PSModule -Name 'TestModule' -SourceDirectory $script:testDir -Tag 'Unit'
+            Should -Invoke Invoke-Pester -Times 1 -Exactly -ParameterFilter {
+                $Configuration.Filter.Tag.Value -contains 'Unit'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Added
- 9 new rules from PSScriptAnalyzer 1.21.0-1.25.0: PSAvoidExclaimOperator, PSAvoidMultipleTypeAttributes, PSAvoidSemicolonsAsLineTerminators, PSAvoidUsingAllowUnencryptedAuthentication, PSAvoidUsingBrokenHashAlgorithms, PSAvoidUsingDoubleQuotesForConstantString, PSUseConsistentParameterSetName, PSUseConsistentParametersKind, PSUseSingleValueFromPipelineParameter
- Unit tests for Publish-PSModule, Test-PSModule, and Invoke-PSModuleAnalyzer
- Stable Guid field in build.ps1

## Changed
- Pester version constraint to 5.*
- PSScriptAnalyzer version constraint to 1.*
- GUID lookup in Build-PSModule.ps1 now uses Save-PSResource and parses the published manifest instead of Find-Module

## Fixed
- Broken GUID discovery via Find-Module.AdditionalMetadata